### PR TITLE
Using same response for create and regenerate

### DIFF
--- a/openapi/components/schemas/apiAccessTokenRequestResult.yml
+++ b/openapi/components/schemas/apiAccessTokenRequestResult.yml
@@ -16,10 +16,7 @@ properties:
   expiry:
     description: When this API access token will expire.
     type: string
-    format: date-time
-  tokenHint:
-    description: This is the first few characters of the token to help users match
-    type: string
+    format: date-time  
   token:
     description: The User's API access token. This will not be returned on GET calls, only on the initial POST
     type: string

--- a/openapi/paths/apiAccessTokens.yml
+++ b/openapi/paths/apiAccessTokens.yml
@@ -21,7 +21,7 @@ post:
       content:
         application/json:
           schema:
-            $ref: '../components/schemas/apiAccessToken.yml'
+            $ref: '../components/schemas/apiAccessTokenRequestResult.yml'
     '400':
       $ref: '../components/responses/400-badRequest.yml'
     '401':


### PR DESCRIPTION
aligned the response for create token and regenerate (I think it is the same thing in the end) + removed tokenHint from that response (as it does not make sense)