### PR TITLE
Add document types, update document

### DIFF
--- a/openapi/components/parameters/header/content-type.yml
+++ b/openapi/components/parameters/header/content-type.yml
@@ -1,0 +1,6 @@
+name: Content-Type
+in: header
+required: true
+description: Content type that is being used.
+schema:
+  type: string

--- a/openapi/components/parameters/path/docTypeId.yml
+++ b/openapi/components/parameters/path/docTypeId.yml
@@ -1,0 +1,6 @@
+name: docTypeId
+in: path
+required: true
+description: The system provided id of a Document Type
+schema:
+  type: string

--- a/openapi/components/parameters/query/contentHash.yml
+++ b/openapi/components/parameters/query/contentHash.yml
@@ -1,0 +1,6 @@
+name: contentHash
+in: query
+required: false
+description: Filter on the 'contentHash' field of a resource.
+schema:
+  type: string

--- a/openapi/components/parameters/query/hasContent.yml
+++ b/openapi/components/parameters/query/hasContent.yml
@@ -1,0 +1,6 @@
+name: hasContent
+in: query
+required: false
+description: Filter out if a document has content or not.
+schema:
+  type: boolean

--- a/openapi/components/parameters/query/type.yml
+++ b/openapi/components/parameters/query/type.yml
@@ -1,0 +1,6 @@
+name: type
+in: query
+required: false
+description: Filter on the 'type' field of a resource.
+schema:
+  type: string

--- a/openapi/components/responses/409-alreadyExists.yml
+++ b/openapi/components/responses/409-alreadyExists.yml
@@ -1,0 +1,5 @@
+description: The server cannot find the requested resource. 
+content:
+  application/json:
+    schema:
+      $ref: './error.yml'

--- a/openapi/components/schemas/common/binary.yml
+++ b/openapi/components/schemas/common/binary.yml
@@ -1,0 +1,2 @@
+type: string
+format: binary

--- a/openapi/components/schemas/common/createdBy.yml
+++ b/openapi/components/schemas/common/createdBy.yml
@@ -1,0 +1,5 @@
+type: object
+properties:
+  createdByUri:
+    description: URI of the user that created the record.
+    type: string

--- a/openapi/components/schemas/common/createdBy.yml
+++ b/openapi/components/schemas/common/createdBy.yml
@@ -1,5 +1,5 @@
 type: object
 properties:
-  createdByUri:
+  createdBy:
     description: URI of the user that created the record.
     type: string

--- a/openapi/components/schemas/common/createdTime.yml
+++ b/openapi/components/schemas/common/createdTime.yml
@@ -1,0 +1,5 @@
+type: object
+properties:
+  createdTime:
+    description: Timestamp of when the record was created.
+    type: string

--- a/openapi/components/schemas/document.yml
+++ b/openapi/components/schemas/document.yml
@@ -28,9 +28,6 @@ properties:
   contentHash:
     description: Sha256 32-byte, base64 encoded contentHash. This will be empty if the document content has not yet been provided.
     type: string
-  content:
-    description: URI to the content.
-    type: string
   originalHash:
     description: Sha256 32-byte, base64 encoded contentHash. For original documents this will match contentHash. It will be different for redacted documents derived from an original document. This will be empty if the document content has not yet been provided.
     type: string

--- a/openapi/components/schemas/document.yml
+++ b/openapi/components/schemas/document.yml
@@ -1,17 +1,30 @@
 type: object
+description: This is a definition of a document.
+required:
+  - name
+  - typeUri
 properties:
-  id:
-    description: System provided identity field.
-    type: string
   name:
-    description: Document name
+    description: Document name.
     type: string
-  type:
-    description: Document type
+  typeUri:
+    description: URI of the document type.
     type: string
-  providedBy:
-    description: Who created/issued the document.
+  providedByUri:
+    description: Entity that provided/issued the document. Can be either organisation or location.
     type: string
-  providedFor:
-    description: Who the document was created for.
+  providedToUri:
+    description: Entity that received the document. Can be either organisation or location.
     type: string
+  issuanceTime:
+    description: The timestamp of when the document has been issued. Can be either just the date or, in cases where better precision is required, - the date and exact time.
+    type: string
+    format: date-time
+  validityStartTime:
+    description: The validity start timestamp of the document. Can be either just the date or, in cases where better precision is required, - the date and exact time.
+    type: string
+    format: date-time
+  validityEndTime:
+    description: The validity end timestamp of the document. Can be either just the date or, in cases where better precision is required, - the date and exact time.
+    type: string
+    format: date-time

--- a/openapi/components/schemas/document.yml
+++ b/openapi/components/schemas/document.yml
@@ -5,26 +5,38 @@ required:
   - typeUri
 properties:
   name:
-    description: Document name.
+    description: Document name
     type: string
-  typeUri:
-    description: URI of the document type.
+  type:
+    description: Document type
     type: string
-  providedByUri:
-    description: Entity that provided/issued the document. Can be either organisation or location.
+  providedBy:
+    description: Who created/issued the document.
     type: string
-  providedToUri:
-    description: Entity that received the document. Can be either organisation or location.
+  providedFor:
+    description: Who the document was created for.
     type: string
-  issuanceTime:
-    description: The timestamp of when the document has been issued. Can be either just the date or, in cases where better precision is required, - the date and exact time.
-    type: string
-    format: date-time
-  validityStartTime:
-    description: The validity start timestamp of the document. Can be either just the date or, in cases where better precision is required, - the date and exact time.
+  issuance: 
+    description: The date and time when this document was issued.
     type: string
     format: date-time
-  validityEndTime:
-    description: The validity end timestamp of the document. Can be either just the date or, in cases where better precision is required, - the date and exact time.
+  validityStart: 
+    description: If the document has a validity period, this is when it starts.
     type: string
     format: date-time
+  validityEnd: 
+    description: If the document has a validity period, this is when it ends.
+    type: string
+    format: date-time
+  contentType:
+    description: The type of the content based on rfc4288 (https://www.rfc-editor.org/rfc/rfc4288)
+    type: string
+  contentHash:
+    description: Sha256 32-byte, base64 encoded contentHash
+    type: string
+  content:
+    description: URI to the content.
+    type: string
+  originalHash:
+    description: Sha256 32-byte, base64 encoded contentHash. For original documents this will match contentHash. It will be different for redacted documents derived from an original document.
+    type: string

--- a/openapi/components/schemas/documentMetadata.yml
+++ b/openapi/components/schemas/documentMetadata.yml
@@ -2,13 +2,13 @@ type: object
 description: This is a definition of a document.
 required:
   - name
-  - typeUri
+  - type
 properties:
   name:
     description: Document name
     type: string
   type:
-    description: Document type
+    description: Document type URI
     type: string
   issuance: 
     description: The date and time when this document was issued.
@@ -24,13 +24,4 @@ properties:
     format: date-time
   contentType:
     description: The type of the content based on rfc4288 (https://www.rfc-editor.org/rfc/rfc4288)
-    type: string
-  contentHash:
-    description: Sha256 32-byte, base64 encoded contentHash. This will be empty if the document content has not yet been provided.
-    type: string
-  content:
-    description: URI to the content.
-    type: string
-  originalHash:
-    description: Sha256 32-byte, base64 encoded contentHash. For original documents this will match contentHash. It will be different for redacted documents derived from an original document. This will be empty if the document content has not yet been provided.
     type: string

--- a/openapi/components/schemas/documentType.yml
+++ b/openapi/components/schemas/documentType.yml
@@ -1,0 +1,8 @@
+type: object
+description: This is a definition of a document type.
+required:
+  - name
+properties:
+  name:
+    description: Document type name.
+    type: string

--- a/openapi/components/schemas/files/content.yml
+++ b/openapi/components/schemas/files/content.yml
@@ -1,0 +1,7 @@
+type: object
+required:
+  - content
+properties:
+  content:
+    description: The base64 encoded content of the file.
+    type: string

--- a/openapi/components/schemas/files/contentUri.yml
+++ b/openapi/components/schemas/files/contentUri.yml
@@ -1,0 +1,5 @@
+type: object
+properties:
+  contentUri:
+    description: The URI to the document binary content.
+    type: string

--- a/openapi/components/schemas/files/contentUri.yml
+++ b/openapi/components/schemas/files/contentUri.yml
@@ -1,5 +1,5 @@
 type: object
 properties:
-  contentUri:
+  content:
     description: The URI to the document binary content.
     type: string

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -123,6 +123,10 @@ paths:
     $ref: ./paths/documents.yml
   /organisations/{orgId}/documents/{docId}:
     $ref: ./paths/document.yml
+  /organisations/{orgId}/document-types:
+    $ref: ./paths/documentTypes.yml
+  /organisations/{orgId}/document-types/{docTypeId}:
+    $ref: ./paths/documentType.yml
   /organisations/{orgId}/locations:
     $ref: ./paths/locations.yml
   /organisations/{orgId}/locations/{locId}:

--- a/openapi/openapi.yml
+++ b/openapi/openapi.yml
@@ -123,6 +123,8 @@ paths:
     $ref: ./paths/documents.yml
   /organisations/{orgId}/documents/{docId}:
     $ref: ./paths/document.yml
+  /organisations/{orgId}/documents/{docId}/content:
+    $ref: ./paths/documentContent.yml
   /organisations/{orgId}/document-types:
     $ref: ./paths/documentTypes.yml
   /organisations/{orgId}/document-types/{docTypeId}:

--- a/openapi/paths/document.yml
+++ b/openapi/paths/document.yml
@@ -32,6 +32,8 @@ put:
       $ref: "../components/responses/403-forbidden.yml"
     "404":
       $ref: "../components/responses/404-notFound.yml"
+    "409":
+      $ref: "../components/responses/409-alreadyExists.yml"      
     "429":
       $ref: "../components/responses/429-tooManyRequests.yml"
     default:

--- a/openapi/paths/document.yml
+++ b/openapi/paths/document.yml
@@ -12,9 +12,7 @@ put:
     content:
       application/json:
         schema:
-          allOf:
-            - $ref: "../components/schemas/document.yml"
-            - $ref: "../components/schemas/files/content.yml"
+          $ref: "../components/schemas/documentMetadata.yml"
     required: true
   responses:
     "200":

--- a/openapi/paths/document.yml
+++ b/openapi/paths/document.yml
@@ -22,7 +22,6 @@ put:
           schema:
             allOf:
               - $ref: "../components/schemas/document.yml"
-              - $ref: "../components/schemas/files/contentUri.yml"
               - $ref: "../components/schemas/common/createdBy.yml"
               - $ref: "../components/schemas/common/createdTime.yml"
     "400":
@@ -54,7 +53,6 @@ get:
           schema:
             allOf:
               - $ref: "../components/schemas/document.yml"
-              - $ref: "../components/schemas/files/contentUri.yml"
               - $ref: "../components/schemas/common/createdBy.yml"
               - $ref: "../components/schemas/common/createdTime.yml"
     "401":

--- a/openapi/paths/documentContent.yml
+++ b/openapi/paths/documentContent.yml
@@ -54,6 +54,8 @@ put:
       $ref: "../components/responses/403-forbidden.yml"
     "404":
       $ref: "../components/responses/404-notFound.yml"
+    "409":
+      $ref: "../components/responses/409-alreadyExists.yml"       
     "429":
       $ref: "../components/responses/429-tooManyRequests.yml"
     default:

--- a/openapi/paths/documentContent.yml
+++ b/openapi/paths/documentContent.yml
@@ -1,0 +1,114 @@
+put:
+  tags:
+    - Documents
+  summary: Add Document Content
+  operationId: uploadContent
+  description: Upload document content
+  parameters:
+    - $ref: "../components/parameters/path/orgId.yml"
+    - $ref: "../components/parameters/path/docId.yml"
+    - $ref: "../components/parameters/header/content-type.yml"
+  requestBody:
+    description: Document content
+    content:
+      application/msword:
+        schema:
+          type: string
+          format: binary
+      application/vnd.openxmlformats-officedocument.wordprocessingml.document:
+        schema:
+          type: string
+          format: binary
+      application/vnd.ms-excel:
+        schema:
+          type: string
+          format: binary
+      application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+        schema:
+          type: string
+          format: binary
+      application/octet-stream:
+        schema:
+          type: string
+          format: binary
+      text/csv:
+        schema:
+          type: string
+      image/*:
+        schema:
+          type: string
+          format: binary
+      application/pdf:
+        schema:
+          type: string
+          format: binary
+    required: true
+  responses:
+    "200":
+      description: Successful operation
+    "400":
+      $ref: "../components/responses/400-badRequest.yml"
+    "401":
+      $ref: "../components/responses/401-unauthorised.yml"
+    "403":
+      $ref: "../components/responses/403-forbidden.yml"
+    "404":
+      $ref: "../components/responses/404-notFound.yml"
+    "429":
+      $ref: "../components/responses/429-tooManyRequests.yml"
+    default:
+      $ref: "../components/responses/500-internalError.yml"
+get:
+  tags:
+    - Documents
+  summary: Get Document Content
+  operationId: getDocumentContent
+  description: Get the document content
+  parameters:
+    - $ref: "../components/parameters/path/orgId.yml"
+    - $ref: "../components/parameters/path/docId.yml"
+  responses:
+    "200":
+      description: Document Content
+      content:
+        application/msword:
+          schema:
+            type: string
+            format: binary
+        application/vnd.openxmlformats-officedocument.wordprocessingml.document:
+          schema:
+            type: string
+            format: binary
+        application/vnd.ms-excel:
+          schema:
+            type: string
+            format: binary
+        application/vnd.openxmlformats-officedocument.spreadsheetml.sheet:
+          schema:
+            type: string
+            format: binary
+        application/octet-stream:
+          schema:
+            type: string
+            format: binary
+        text/csv:
+          schema:
+            type: string
+        image/*:
+          schema:
+            type: string
+            format: binary
+        application/pdf:
+          schema:
+            type: string
+            format: binary
+    "401":
+      $ref: "../components/responses/401-unauthorised.yml"
+    "403":
+      $ref: "../components/responses/403-forbidden.yml"
+    "404":
+      $ref: "../components/responses/404-notFound.yml"
+    "429":
+      $ref: "../components/responses/429-tooManyRequests.yml"
+    default:
+      $ref: "../components/responses/500-internalError.yml"

--- a/openapi/paths/documentType.yml
+++ b/openapi/paths/documentType.yml
@@ -33,6 +33,8 @@ put:
       $ref: "../components/responses/403-forbidden.yml"
     "404":
       $ref: "../components/responses/404-notFound.yml"
+    "409":
+      $ref: "../components/responses/409-alreadyExists.yml"       
     "429":
       $ref: "../components/responses/429-tooManyRequests.yml"
     default:

--- a/openapi/paths/documentType.yml
+++ b/openapi/paths/documentType.yml
@@ -1,20 +1,18 @@
 put:
   tags:
     - Documents
-  summary: Update document
-  operationId: updateDocument
-  description: Update document by id
+  summary: Update document type
+  operationId: updateDocumentType
+  description: Update document type by id
   parameters:
     - $ref: "../components/parameters/path/orgId.yml"
-    - $ref: "../components/parameters/path/docId.yml"
+    - $ref: "../components/parameters/path/docTypeId.yml"
   requestBody:
-    description: Update document information
+    description: Update document type information
     content:
       application/json:
         schema:
-          allOf:
-            - $ref: "../components/schemas/document.yml"
-            - $ref: "../components/schemas/files/content.yml"
+          $ref: "../components/schemas/documentType.yml"
     required: true
   responses:
     "200":
@@ -23,8 +21,8 @@ put:
         application/json:
           schema:
             allOf:
-              - $ref: "../components/schemas/document.yml"
-              - $ref: "../components/schemas/files/contentUri.yml"
+              - $ref: "../components/schemas/id.yml"
+              - $ref: "../components/schemas/documentType.yml"
               - $ref: "../components/schemas/common/createdBy.yml"
               - $ref: "../components/schemas/common/createdTime.yml"
     "400":
@@ -42,21 +40,20 @@ put:
 get:
   tags:
     - Documents
-  summary: Get Document
-  operationId: getDocument
-  description: Get the document details
+  summary: Get Document Type
+  operationId: getDocumentType
+  description: Get the document type details
   parameters:
     - $ref: "../components/parameters/path/orgId.yml"
-    - $ref: "../components/parameters/path/docId.yml"
+    - $ref: "../components/parameters/path/docTypeId.yml"
   responses:
     "200":
-      description: Document info
+      description: Document type info
       content:
         application/json:
           schema:
             allOf:
-              - $ref: "../components/schemas/document.yml"
-              - $ref: "../components/schemas/files/contentUri.yml"
+              - $ref: "../components/schemas/documentType.yml"
               - $ref: "../components/schemas/common/createdBy.yml"
               - $ref: "../components/schemas/common/createdTime.yml"
     "401":

--- a/openapi/paths/documentTypes.yml
+++ b/openapi/paths/documentTypes.yml
@@ -1,16 +1,16 @@
 get:
   tags:
     - Documents
-  summary: List Documents
-  operationId: listDocuments
-  description: List all the Documents
+  summary: List Document Types
+  operationId: listDocumentTypes
+  description: List all the Documents Types
   parameters:
     - $ref: "../components/parameters/path/orgId.yml"
     - $ref: "../components/parameters/query/page.yml"
     - $ref: "../components/parameters/query/size.yml"
   responses:
     "200":
-      description: Array of Documents
+      description: Array of Document Types
       content:
         application/json:
           schema:
@@ -23,8 +23,7 @@ get:
                     items:
                       allOf:
                         - $ref: "../components/schemas/id.yml"
-                        - $ref: "../components/schemas/document.yml"
-                        - $ref: "../components/schemas/files/contentUri.yml"
+                        - $ref: "../components/schemas/documentType.yml"
                         - $ref: "../components/schemas/common/createdBy.yml"
                         - $ref: "../components/schemas/common/createdTime.yml"
     "401":
@@ -38,19 +37,17 @@ get:
 post:
   tags:
     - Documents
-  summary: Add document
-  operationId: addDocument
-  description: Add a new Document
+  summary: Add document type
+  operationId: addDocumentType
+  description: Add a new Document Type
   parameters:
     - $ref: "../components/parameters/path/orgId.yml"
   requestBody:
-    description: Document information
+    description: Document type information
     content:
       application/json:
         schema:
-          allOf:
-            - $ref: "../components/schemas/document.yml"
-            - $ref: "../components/schemas/files/content.yml"
+          $ref: "../components/schemas/documentType.yml"
   responses:
     "201":
       description: Successful operation
@@ -59,8 +56,7 @@ post:
           schema:
             allOf:
               - $ref: "../components/schemas/id.yml"
-              - $ref: "../components/schemas/document.yml"
-              - $ref: "../components/schemas/files/contentUri.yml"
+              - $ref: "../components/schemas/documentType.yml"
               - $ref: "../components/schemas/common/createdBy.yml"
               - $ref: "../components/schemas/common/createdTime.yml"
     "400":

--- a/openapi/paths/documentTypes.yml
+++ b/openapi/paths/documentTypes.yml
@@ -65,6 +65,8 @@ post:
       $ref: "../components/responses/401-unauthorised.yml"
     "403":
       $ref: "../components/responses/403-forbidden.yml"
+    "409":
+      $ref: "../components/responses/409-alreadyExists.yml"       
     "429":
       $ref: "../components/responses/429-tooManyRequests.yml"
     default:

--- a/openapi/paths/documents.yml
+++ b/openapi/paths/documents.yml
@@ -8,6 +8,10 @@ get:
     - $ref: "../components/parameters/path/orgId.yml"
     - $ref: "../components/parameters/query/page.yml"
     - $ref: "../components/parameters/query/size.yml"
+    - $ref: "../components/parameters/query/hasContent.yml"
+    - $ref: "../components/parameters/query/name.yml"
+    - $ref: "../components/parameters/query/type.yml"
+    - $ref: "../components/parameters/query/contentHash.yml"
   responses:
     "200":
       description: Array of Documents
@@ -24,7 +28,6 @@ get:
                       allOf:
                         - $ref: "../components/schemas/id.yml"
                         - $ref: "../components/schemas/document.yml"
-                        - $ref: "../components/schemas/files/contentUri.yml"
                         - $ref: "../components/schemas/common/createdBy.yml"
                         - $ref: "../components/schemas/common/createdTime.yml"
     "401":
@@ -48,19 +51,21 @@ post:
     content:
       application/json:
         schema:
-          allOf:
-            - $ref: "../components/schemas/document.yml"
-            - $ref: "../components/schemas/files/content.yml"
+          $ref: "../components/schemas/documentMetadata.yml"
   responses:
     "201":
       description: Successful operation
+      headers:
+        Content-Location:
+          schema:
+            type: string
+          description: Location to upload the content to.
       content:
         application/json:
           schema:
             allOf:
               - $ref: "../components/schemas/id.yml"
               - $ref: "../components/schemas/document.yml"
-              - $ref: "../components/schemas/files/contentUri.yml"
               - $ref: "../components/schemas/common/createdBy.yml"
               - $ref: "../components/schemas/common/createdTime.yml"
     "400":


### PR DESCRIPTION
- Add document type endpoints and schemas;
- Add `Uri` part to existing document parameters that will be URIs;
- Add `issuanceTime`, `validityStartTime`, `validityEndTime` parameters to document;
- Add `content` parameter to POST document requests to reflect the fact that the binary doc content will have to be provided by the user;
- Add `contentUri` parameter to GET document requests to reflect the fact that the binary content will be retrievable through a separate URI;
- Add `createdByUri` and `createdTime` parameters as common parameters that will be repeating for most of the entities;