### PR TITLE
Add state query parameter to standard and standard type

### DIFF
--- a/openapi/components/parameters/query/state.yml
+++ b/openapi/components/parameters/query/state.yml
@@ -1,0 +1,6 @@
+name: state
+in: query
+required: false
+description: The state of an entity.
+schema:
+  $ref: "../../schemas/enums/state.yml"

--- a/openapi/paths/Common/standard.yml
+++ b/openapi/paths/Common/standard.yml
@@ -33,6 +33,10 @@ put:
       $ref: "../../components/responses/403-forbidden.yml"
     "404":
       $ref: "../../components/responses/404-notFound.yml"
+    "409":
+      $ref: "../../components/responses/409-conflict.yml"
+    "422":
+      $ref: "../../components/responses/422-unprocessable.yml"
     "429":
       $ref: "../../components/responses/429-tooManyRequests.yml"
     default:

--- a/openapi/paths/Common/standardType.yml
+++ b/openapi/paths/Common/standardType.yml
@@ -34,6 +34,10 @@ put:
       $ref: "../../components/responses/403-forbidden.yml"
     "404":
       $ref: "../../components/responses/404-notFound.yml"
+    "409":
+      $ref: "../../components/responses/409-conflict.yml"
+    "422":
+      $ref: "../../components/responses/422-unprocessable.yml"
     "429":
       $ref: "../../components/responses/429-tooManyRequests.yml"
     default:

--- a/openapi/paths/Common/standardTypes.yml
+++ b/openapi/paths/Common/standardTypes.yml
@@ -6,6 +6,7 @@ get:
   description: Endpoint to retrieve all the types of a standard defined in the system.
   parameters:
     - $ref: "../../components/parameters/path/standardId.yml"
+    - $ref: "../../components/parameters/query/state.yml"
   responses:
     "200":
       description: Array of Standard Types
@@ -55,8 +56,10 @@ post:
       $ref: "../../components/responses/401-unauthorised.yml"
     "403":
       $ref: "../../components/responses/403-forbidden.yml"
-    "404":
-      $ref: "../../components/responses/404-notFound.yml"
+    "409":
+      $ref: "../../components/responses/409-conflict.yml"
+    "422":
+      $ref: "../../components/responses/422-unprocessable.yml"
     "429":
       $ref: "../../components/responses/429-tooManyRequests.yml"
     default:

--- a/openapi/paths/Common/standards.yml
+++ b/openapi/paths/Common/standards.yml
@@ -4,6 +4,8 @@ get:
   summary: List Standards
   operationId: listStandards
   description: Endpoint to retrieve all the standards defined in the system.
+  parameters:
+    - $ref: "../../components/parameters/query/state.yml"
   responses:
     "200":
       description: Array of Standards
@@ -51,8 +53,10 @@ post:
       $ref: "../../components/responses/401-unauthorised.yml"
     "403":
       $ref: "../../components/responses/403-forbidden.yml"
-    "404":
-      $ref: "../../components/responses/404-notFound.yml"
+    "409":
+      $ref: "../../components/responses/409-conflict.yml"
+    "422":
+      $ref: "../../components/responses/422-unprocessable.yml"
     "429":
       $ref: "../../components/responses/429-tooManyRequests.yml"
     default:


### PR DESCRIPTION
- Add state query parameter, so that the client can request only "ACTIVE" standard / standard type when creating certificates;
- Improved HTTP errors;