### PR TITLE
Remove userDefinedUnits from products

### DIFF
--- a/openapi/components/schemas/product.yml
+++ b/openapi/components/schemas/product.yml
@@ -9,16 +9,10 @@ properties:
     description: This is the name for the product.
     type: string
   allowedMaterials:
-    description: URI for the materials that are allowed to be used for this product.
+    description: URI(s) for the material(s) that are allowed to be used for this product.
     type: array
     items:
       type: string
   baseUnit:
     description: URI for the base unit of measurements that this product is based off.
     type: string
-  userDefinedUnits:
-    description: List of URIs for user defined units that are attached to this Product for conversion purposes.
-    type: array
-    items:
-      type: string
-

--- a/openapi/paths/product.yml
+++ b/openapi/paths/product.yml
@@ -5,38 +5,42 @@ put:
   operationId: updateProduct
   description: This endpoint allows a product to be updated.
   parameters:
-    - $ref: '../components/parameters/path/orgId.yml'
-    - $ref: '../components/parameters/path/prodId.yml'
+    - $ref: "../components/parameters/path/orgId.yml"
+    - $ref: "../components/parameters/path/prodId.yml"
   requestBody:
     description: Update product information
     content:
       application/json:
         schema:
           allOf:
-            - $ref: '../components/schemas/id.yml'
-            - $ref: '../components/schemas/product.yml'
+            - $ref: "../components/schemas/id.yml"
+            - $ref: "../components/schemas/product.yml"
     required: true
   responses:
-    '200':
+    "200":
       description: Successful operation
       content:
         application/json:
           schema:
             allOf:
-              - $ref: '../components/schemas/id.yml'
-              - $ref: '../components/schemas/product.yml'
-    '400':
-      $ref: '../components/responses/400-badRequest.yml'
-    '401':
-      $ref: '../components/responses/401-unauthorised.yml'
-    '403':
-      $ref: '../components/responses/403-forbidden.yml'
-    '404':
-      $ref: '../components/responses/404-notFound.yml'
-    '429':
-      $ref: '../components/responses/429-tooManyRequests.yml'
+              - $ref: "../components/schemas/id.yml"
+              - $ref: "../components/schemas/product.yml"
+    "400":
+      $ref: "../components/responses/400-badRequest.yml"
+    "401":
+      $ref: "../components/responses/401-unauthorised.yml"
+    "403":
+      $ref: "../components/responses/403-forbidden.yml"
+    "404":
+      $ref: "../components/responses/404-notFound.yml"
+    "409":
+      $ref: "../components/responses/409-conflict.yml"
+    "422":
+      $ref: "../components/responses/422-unprocessable.yml"
+    "429":
+      $ref: "../components/responses/429-tooManyRequests.yml"
     default:
-      $ref: '../components/responses/500-internalError.yml'
+      $ref: "../components/responses/500-internalError.yml"
 get:
   tags:
     - Products
@@ -44,24 +48,24 @@ get:
   operationId: getProduct
   description: This endpoint returns the specific details for a given product.
   parameters:
-    - $ref: '../components/parameters/path/orgId.yml'
-    - $ref: '../components/parameters/path/prodId.yml'
+    - $ref: "../components/parameters/path/orgId.yml"
+    - $ref: "../components/parameters/path/prodId.yml"
   responses:
-    '200':
+    "200":
       description: Product info
       content:
         application/json:
           schema:
             allOf:
-              - $ref: '../components/schemas/id.yml'
-              - $ref: '../components/schemas/product.yml'
-    '401':
-      $ref: '../components/responses/401-unauthorised.yml'
-    '403':
-      $ref: '../components/responses/403-forbidden.yml'
-    '404':
-      $ref: '../components/responses/404-notFound.yml'
-    '429':
-      $ref: '../components/responses/429-tooManyRequests.yml'
+              - $ref: "../components/schemas/id.yml"
+              - $ref: "../components/schemas/product.yml"
+    "401":
+      $ref: "../components/responses/401-unauthorised.yml"
+    "403":
+      $ref: "../components/responses/403-forbidden.yml"
+    "404":
+      $ref: "../components/responses/404-notFound.yml"
+    "429":
+      $ref: "../components/responses/429-tooManyRequests.yml"
     default:
-      $ref: '../components/responses/500-internalError.yml'
+      $ref: "../components/responses/500-internalError.yml"

--- a/openapi/paths/products.yml
+++ b/openapi/paths/products.yml
@@ -5,38 +5,38 @@ get:
   operationId: listProducts
   description: This endpoint returns all the products that have either been defined by the organisation or have been provided by other organisations.
   parameters:
-    - $ref: '../components/parameters/path/orgId.yml'
-    - $ref: '../components/parameters/query/page.yml'
-    - $ref: '../components/parameters/query/size.yml'
-    - $ref: '../components/parameters/query/name.yml'
-    - $ref: '../components/parameters/query/material.yml'
-    - $ref: '../components/parameters/query/material-category.yml'
-    - $ref: '../components/parameters/query/base-unit.yml'
-    - $ref: '../components/parameters/query/unit-type.yml'
+    - $ref: "../components/parameters/path/orgId.yml"
+    - $ref: "../components/parameters/query/page.yml"
+    - $ref: "../components/parameters/query/size.yml"
+    - $ref: "../components/parameters/query/name.yml"
+    - $ref: "../components/parameters/query/material.yml"
+    - $ref: "../components/parameters/query/material-category.yml"
+    - $ref: "../components/parameters/query/base-unit.yml"
+    - $ref: "../components/parameters/query/unit-type.yml"
   responses:
-    '200':
+    "200":
       description: Array of Products
       content:
         application/json:
           schema:
             allOf:
-              - $ref: '../components/schemas/pagination.yml'
+              - $ref: "../components/schemas/pagination.yml"
               - type: object
                 properties:
-                  results: 
+                  results:
                     type: array
-                    items: 
+                    items:
                       allOf:
-                        - $ref: '../components/schemas/id.yml'
-                        - $ref: '../components/schemas/product.yml'
-    '401':
-      $ref: '../components/responses/401-unauthorised.yml'
-    '403':
-      $ref: '../components/responses/403-forbidden.yml'
-    '429':
-      $ref: '../components/responses/429-tooManyRequests.yml'
+                        - $ref: "../components/schemas/id.yml"
+                        - $ref: "../components/schemas/product.yml"
+    "401":
+      $ref: "../components/responses/401-unauthorised.yml"
+    "403":
+      $ref: "../components/responses/403-forbidden.yml"
+    "429":
+      $ref: "../components/responses/429-tooManyRequests.yml"
     default:
-      $ref: '../components/responses/500-internalError.yml'
+      $ref: "../components/responses/500-internalError.yml"
 post:
   tags:
     - Products
@@ -44,29 +44,33 @@ post:
   operationId: addProduct
   description: Add a new Product
   parameters:
-    - $ref: '../components/parameters/path/orgId.yml'
+    - $ref: "../components/parameters/path/orgId.yml"
   requestBody:
     description: Product information
     content:
       application/json:
         schema:
-          $ref: '../components/schemas/product.yml'
+          $ref: "../components/schemas/product.yml"
   responses:
-    '201':
+    "201":
       description: Successful operation
       content:
         application/json:
           schema:
             allOf:
-              - $ref: '../components/schemas/id.yml'
-              - $ref: '../components/schemas/product.yml'
-    '400':
-      $ref: '../components/responses/400-badRequest.yml'
-    '401':
-      $ref: '../components/responses/401-unauthorised.yml'
-    '403':
-      $ref: '../components/responses/403-forbidden.yml'
-    '429':
-      $ref: '../components/responses/429-tooManyRequests.yml'
+              - $ref: "../components/schemas/id.yml"
+              - $ref: "../components/schemas/product.yml"
+    "400":
+      $ref: "../components/responses/400-badRequest.yml"
+    "401":
+      $ref: "../components/responses/401-unauthorised.yml"
+    "403":
+      $ref: "../components/responses/403-forbidden.yml"
+    "409":
+      $ref: "../components/responses/409-conflict.yml"
+    "422":
+      $ref: "../components/responses/422-unprocessable.yml"
+    "429":
+      $ref: "../components/responses/429-tooManyRequests.yml"
     default:
-      $ref: '../components/responses/500-internalError.yml'
+      $ref: "../components/responses/500-internalError.yml"


### PR DESCRIPTION
- Remove `userDefinedUnits` from product model, as we currently do not have such an entity;
- Update product: add 409 error (if user changes product name and such product already exists) & 422 (if there are errors in parameters);
- Add product: add 409 error (if such product already exists) & 422 error (if there are errors in parameters);