### PR TITLE
Change `type` to `types` in locations

### DIFF
--- a/openapi/components/schemas/location.yml
+++ b/openapi/components/schemas/location.yml
@@ -7,8 +7,8 @@ properties:
   name:
     description: The name of the location.
     type: string
-  type:
-    description: The URI of the type(s) of the location.
+  types:
+    description: The URI(s) of the type(s) of the location.
     type: array
     items:
       type: string


### PR DESCRIPTION
- Change `type` parameter to `types` to make it clear that a location can have several types;